### PR TITLE
Add JSON conversion warnings, store save-type metadata and use ns file timestamps (v0.8.2)

### DIFF
--- a/dh5/__config__.py
+++ b/dh5/__config__.py
@@ -1,3 +1,3 @@
 """This file contains all package constants."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/dh5/dh5_class/data_transformation.py
+++ b/dh5/dh5_class/data_transformation.py
@@ -1,6 +1,7 @@
 """Data transformation utils."""
 
 import json
+import logging
 from typing import Iterable, Optional, Sized
 
 import numpy as np
@@ -90,7 +91,27 @@ def transform_on_open(value):
     return value
 
 
-def transform_not_dict_on_save(value, level=0):
+def _warn_json_conversion_if_needed(
+    value_to_dump, converted_payload: str, mode: str, *, key: Optional[str] = None
+):
+    if mode == "mute":
+        return
+    if mode not in {"all", "auto"}:
+        raise ValueError("json_conversion_mode should be one of: 'all', 'auto', 'mute'")
+    if mode == "auto" and len(converted_payload) < 1024:
+        return
+    key_info = f" for key '{key}'" if key else ""
+    logging.warning(
+        "DH5 converted value%s to JSON string before saving (type=%s, approx_size=%dB).",
+        key_info,
+        type(value_to_dump).__name__,
+        len(converted_payload),
+    )
+
+
+def transform_not_dict_on_save(
+    value, level=0, *, json_conversion_mode: str = "auto", key: Optional[str] = None
+):
     """Transform data during saving of h5 file if data is not a dict."""
     if isinstance(value, np.ndarray):
         if level == 0:
@@ -100,13 +121,24 @@ def transform_not_dict_on_save(value, level=0):
     if isinstance(value, (list)) and (np_array_check(value) < 0):
         try:
             if level == 0:
-                return "__json__" + json.dumps(value)
+                converted = json.dumps(value)
+                _warn_json_conversion_if_needed(
+                    value, converted, json_conversion_mode, key=key
+                )
+                return "__json__" + converted
             return value
         except TypeError:
             value_transformed = [
-                transform_not_dict_on_save(v, level=level + 1) for v in value
+                transform_not_dict_on_save(
+                    v, level=level + 1, json_conversion_mode="mute", key=key
+                )
+                for v in value
             ]
-            return "__json__" + json.dumps(value_transformed)
+            converted = json.dumps(value_transformed)
+            _warn_json_conversion_if_needed(
+                value, converted, json_conversion_mode, key=key
+            )
+            return "__json__" + converted
 
     if callable(value):
         from .transformation_types import function_save

--- a/dh5/dh5_class/dict_structure.py
+++ b/dh5/dh5_class/dict_structure.py
@@ -7,7 +7,8 @@ import numpy as np
 
 
 def output_dict_structure(
-    data: dict, additional_info: Optional[Dict[str, str]] = None
+    data: dict,
+    additional_info: Optional[Dict[str, str]] = None,
 ) -> str:
     """Convert a dictionary into a JSON-like string representation of its structure.
 
@@ -57,7 +58,9 @@ def get_dict_structure(data: dict, level: int = 3) -> dict:
         if isinstance(v, dict):
             if level:
                 internal_structure = (
-                    get_dict_structure(v, level=level - 1) if len(v) else "empty dict"
+                    get_dict_structure(v, level=level - 1)
+                    if len(v)
+                    else "empty dict"
                 )
                 structure[k] = (
                     "variable of type dict"
@@ -76,6 +79,7 @@ def get_dict_structure(data: dict, level: int = 3) -> dict:
             structure[k] = f"{str_value} (type : {type(v).__name__})"
         else:
             structure[k] = f"variable of type {type(v).__name__}"
+
     return structure
 
 

--- a/dh5/dh5_class/h5py_utils.py
+++ b/dh5/dh5_class/h5py_utils.py
@@ -112,6 +112,8 @@ def save_sub_dict(
     data: Union[dict, list, np.ndarray, ClassWithAsdict],
     key: str,
     use_compression: Optional[Union[Literal[True], str]] = None,
+    json_conversion_mode: str = "auto",
+    storage_type: Optional[dict] = None,
 ):
     """Save the dict to a group. Each object is converted to a dict, array or simple value.
 
@@ -132,9 +134,27 @@ def save_sub_dict(
     if isinstance(data, dict):
         g = group.create_group(key)
         for k, v in data.items():
-            save_sub_dict(g, v, k, use_compression=use_compression)
+            save_sub_dict(
+                g,
+                v,
+                k,
+                use_compression=use_compression,
+                json_conversion_mode=json_conversion_mode,
+                storage_type=storage_type,
+            )
     elif (key is not None) and (data is not None):
-        data = transform_not_dict_on_save(data)  # type: ignore
+        data = transform_not_dict_on_save(  # type: ignore
+            data, json_conversion_mode=json_conversion_mode, key=key
+        )
+        if storage_type is not None:
+            if isinstance(data, str) and data.startswith("__json__"):
+                storage_type[key] = "JSON string"
+            elif isinstance(data, str) and data.startswith("__function__"):
+                storage_type[key] = "serialized function"
+            elif isinstance(data, (list, np.ndarray)):
+                storage_type[key] = "H5 dataset"
+            else:
+                storage_type[key] = type(data).__name__
         if isinstance(data, (np.ndarray, list)):
             use_compression = "gzip" if use_compression is True else use_compression
             group.create_dataset(
@@ -149,7 +169,9 @@ def save_dict(
     data: dict,
     key_prefix: Optional[str] = None,
     use_compression: Optional[Union[Literal[True], str]] = None,
-) -> float:
+    json_conversion_mode: str = "auto",
+    storage_type: Optional[dict] = None,
+) -> int:
     """Save dict to h5 file.
 
     Args:
@@ -160,9 +182,12 @@ def save_dict(
         use_compression (str|True, optional): If compression should be used. If true,
          'gzip' is used, otherwise you can specify compression by providing a str.
          Defaults to not compressed.
+        json_conversion_mode (str, optional): Warning mode for list->JSON conversions.
+         Available values are `all`, `auto`, `mute`. Defaults to `auto`.
+        storage_type (dict, optional): Mutable dictionary filled with key->saved-type metadata.
 
     Returns:
-        float: Time of the last modification of the file.
+        int: Nanosecond-resolution time of the last file modification.
 
     Example:
         ```
@@ -184,8 +209,15 @@ def save_dict(
                 file.pop(key)
             if value is None:
                 continue
-            save_sub_dict(file, value, key, use_compression=use_compression)
-    return os.path.getmtime(filename)
+            save_sub_dict(
+                file,
+                value,
+                key,
+                use_compression=use_compression,
+                json_conversion_mode=json_conversion_mode,
+                storage_type=storage_type,
+            )
+    return os.stat(filename).st_mtime_ns
 
 
 # -------------- Load keys ----------------

--- a/dh5/dh5_class/main.py
+++ b/dh5/dh5_class/main.py
@@ -80,7 +80,9 @@ class DH5:
     _raise_file_locked_error: bool = False
     _retry_on_file_locked_error: int = 5
     _last_time_data_checked: float = 0
-    _file_modified_time: float = 0
+    _file_modified_time: int = 0
+    _file_size: int = 0
+    _saved_storage_type: Dict[str, str]
     __should_initialized: bool = False
     __should_not_be_converted__ = True
 
@@ -96,6 +98,7 @@ class DH5:
         overwrite: Optional[bool] = None,
         data: Optional[dict] = None,
         open_on_init: Optional[bool] = None,
+        json_conversion_mode: Literal["all", "auto", "mute"] = "auto",
         **kwds,
     ):
         """DH5.
@@ -113,6 +116,9 @@ class DH5:
             data (Optional[dict], optional):
                 Data to load. If data provided, file . Defaults to None.
             open_on_init (Optional[bool], optional): open_on_init. Defaults to True.
+            json_conversion_mode (Literal["all", "auto", "mute"], optional):
+                Warning mode for list-to-JSON conversion during save.
+                Defaults to "auto".
 
         """
         if mode is not None:
@@ -142,7 +148,15 @@ class DH5:
         self._keys: Set[str] = set(self._data.keys())
         self._last_update = set()
         self._save_on_edit = save_on_edit
+        self._json_conversion_mode: Literal["all", "auto", "mute"] = (
+            json_conversion_mode
+        )
+        if self._json_conversion_mode not in {"all", "auto", "mute"}:
+            raise ValueError(
+                "json_conversion_mode should be one of: 'all', 'auto', 'mute'"
+            )
         self._classes_should_be_saved_internally = set()
+        self._saved_storage_type = {}
         self._key_prefix: Optional[str] = kwds.get("key_prefix")
 
         if read_only is None:
@@ -256,7 +270,9 @@ class DH5:
             raise ValueError("Filepath is not specified. So cannot load_h5")
         filepath = filepath if filepath.endswith(".h5") else filepath + ".h5"
         data = h5py_utils.open_h5(filepath, key=key, key_prefix=self._key_prefix)
-        self._file_modified_time = os.path.getmtime(filepath)
+        stat = os.stat(filepath)
+        self._file_modified_time = stat.st_mtime_ns
+        self._file_size = stat.st_size
         return self._update(data)
 
     def load(
@@ -356,10 +372,14 @@ class DH5:
         self._pre_save()
         self._keys.add(key)
         self._last_update.add(key)
+        if key in self._saved_storage_type:
+            self._saved_storage_type.pop(key)
 
     def __del_key(self, key):
         self._keys.remove(key)
         self._last_update.add(key)
+        if key in self._saved_storage_type:
+            self._saved_storage_type.pop(key)
 
     def __check_read_only_true(self, key):
         """Return true if data with this key is only available for read.
@@ -738,13 +758,15 @@ class DH5:
 
     def _get_repr(self):
         if self._repr is None:
-            additional_info = (
-                {key: " (r)" for key in self._read_only}
-                if isinstance(self._read_only, set)
-                else None
-            )
+            additional_info: Dict[str, str] = {}
+            if isinstance(self._read_only, set):
+                additional_info = {key: " (r)" for key in self._read_only}
+            for key, storage_type in self._saved_storage_type.items():
+                postfix = f" [saved as {storage_type}]"
+                additional_info[key] = additional_info.get(key, "") + postfix
             self._repr = output_dict_structure(
-                self._data, additional_info=additional_info
+                self._data,
+                additional_info=additional_info if additional_info else None,
             ) + (
                 f"\nUnloaded keys: {self._unopened_keys}" if self._unopened_keys else ""
             )
@@ -886,9 +908,29 @@ class DH5:
         for i in range(self._retry_on_file_locked_error):
             try:
                 # print("_raise_file_locked_error", self._raise_file_locked_error, list(data.keys()))
+                storage_type = {}
                 self._file_modified_time = h5py_utils.save_dict(
-                    filename=filepath + ".h5", data=data, key_prefix=self._key_prefix
+                    filename=filepath + ".h5",
+                    data=data,
+                    key_prefix=self._key_prefix,
+                    json_conversion_mode=self._json_conversion_mode,
+                    storage_type=storage_type,
                 )
+                for key, value in data.items():
+                    if value is None:
+                        self._saved_storage_type.pop(key, None)
+                        continue
+                    if isinstance(value, dict):
+                        self._saved_storage_type.pop(key, None)
+                        continue
+                    saved_key = (
+                        f"{self._key_prefix}/{key}" if self._key_prefix else key
+                    )
+                    if saved_key in storage_type:
+                        self._saved_storage_type[key] = storage_type[saved_key]
+                stat = os.stat(filepath + ".h5")
+                self._file_modified_time = stat.st_mtime_ns
+                self._file_size = stat.st_size
                 return
             except h5py_utils.FileLockedError as error:
                 if self._raise_file_locked_error:
@@ -967,8 +1009,10 @@ class DH5:
         """
         if self.filepath is None:
             raise ValueError("Cannot pull from file if it's not been set")
-        file_modified = os.path.getmtime(self.filepath + ".h5")
-        return self._file_modified_time != file_modified
+        stat = os.stat(self.filepath + ".h5")
+        return (self._file_modified_time != stat.st_mtime_ns) or (
+            self._file_size != stat.st_size
+        )
 
     def pull(self, force_pull: bool = False):
         """Pull data from a file and reloads it into the object.

--- a/tests/dh5_class_tests/main_test.py
+++ b/tests/dh5_class_tests/main_test.py
@@ -8,7 +8,9 @@ everything is good.
 
 import os
 import shutil
+import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -248,11 +250,49 @@ class WithoutSavingTest(unittest.TestCase):
         self.data_smart["ab3"] = 123.45
         self.data_smart["ab4"] = {"a": 567, "b": {"c": {"d": {"e": {"f": "g"}}}}}
         self.data_smart["ab5"] = Test()
+        self.data_smart["ab6"] = [1, "a", {"b": 2}]
         rep = repr(self.data_smart)
-        for key in ["ab1", "ab2", "ab3", "ab4", "ab5"]:
+        for key in ["ab1", "ab2", "ab3", "ab4", "ab5", "ab6"]:
             self.assertIn(key, rep)
 
         self.assertIn("Test", rep)
+
+    def test_repr_contains_saved_type_after_save(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            filepath = os.path.join(tmp_dir, "repr_saved_type")
+            d = DH5(filepath, overwrite=True, save_on_edit=True, json_conversion_mode="mute")
+            d["mixed"] = [1, "a", {"b": 2}]
+            d["nested"] = {"a": 1}
+            rep = repr(d)
+            self.assertIn("[saved as JSON string]", rep)
+            self.assertNotIn('"nested" [saved as', rep)
+
+    def test_json_conversion_warning_modes(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            filepath = os.path.join(tmp_dir, "warning_mode_test")
+
+            with self.assertLogs(level="WARNING") as all_logs:
+                d_all = DH5(
+                    filepath,
+                    overwrite=True,
+                    save_on_edit=True,
+                    json_conversion_mode="all",
+                )
+                d_all["mixed"] = [1, "a", {"b": 2}]
+            self.assertIn("converted value", " ".join(all_logs.output))
+
+            with self.assertRaises(ValueError):
+                DH5(filepath, overwrite=True, json_conversion_mode="invalid")  # type: ignore
+
+            with patch("dh5.dh5_class.data_transformation.logging.warning") as log_mock:
+                d_mute = DH5(
+                    filepath,
+                    overwrite=True,
+                    save_on_edit=True,
+                    json_conversion_mode="mute",
+                )
+                d_mute["mixed"] = [1, "a", {"b": 2}]
+            log_mock.assert_not_called()
 
     def test_keys_tree(self):
         data = self.create_random_data()


### PR DESCRIPTION
### Motivation (#6)

- Improve visibility when lists are coerced to JSON strings during save and allow controlling warning behavior. 
- Record how values were stored (e.g. JSON string, H5 dataset, serialized function) and surface that in the object representation. 
- Increase file-modification precision and robustness by using nanosecond timestamps and file size to detect external changes.

### Description

- Added a JSON-conversion warning helper `_warn_json_conversion_if_needed` and extended `transform_not_dict_on_save` to accept `json_conversion_mode` and `key` so conversions can warn in modes `all`, `auto`, or be muted; recursive calls mute warnings.
- Extended `save_sub_dict` and `save_dict` to accept `json_conversion_mode` and a `storage_type` dict to collect metadata about how each key was stored, and changed `save_dict` to return nanosecond-resolution modification time (`int`) instead of `float` mtime.
- Tracked file `st_size` and `st_mtime_ns` in `DH5`, updated loading/saving logic to use `os.stat(...).st_mtime_ns` and `st_size`, and updated `pull_available` to compare both mtime and size.
- Stored per-key saved-type metadata in `DH5._saved_storage_type` and appended saved-type postfixes to the repr via `output_dict_structure` additional info.
- Added validation for constructor parameter `json_conversion_mode` and defaulted it to `"auto"` in `DH5`.
- Minor refactor/formatting in `dict_structure.py` and ensured warnings/logging import in `data_transformation.py`.

### Testing

- Ran the unit tests in `tests/dh5_class_tests/main_test.py`, including newly added `test_repr_contains_saved_type_after_save` and `test_json_conversion_warning_modes`, and they passed under the unittest run.
- Existing API-level tests (save/open/representation) were executed and succeeded.
